### PR TITLE
Don't use finalizers on Problem

### DIFF
--- a/glpk/glpk.go
+++ b/glpk/glpk.go
@@ -39,7 +39,6 @@ package glpk
 
 import (
 	"reflect"
-	"runtime"
 	"unsafe"
 )
 
@@ -98,17 +97,10 @@ type Prob struct {
 	p *prob
 }
 
-func finalizeProb(p *prob) {
-	if p.p != nil {
-		C.glp_delete_prob(p.p)
-		p.p = nil
-	}
-}
 
 // New creates a new optimization problem.
 func New() *Prob {
 	p := &prob{C.glp_create_prob()}
-	runtime.SetFinalizer(p, finalizeProb)
 	return &Prob{p}
 }
 


### PR DESCRIPTION
I'm not really sure that it's a great approach to use finalizers like this.

There's actually a bug I'm running into when (very occasionally) sometimes the program is aborting from inside `glp_delete_prob`. The bug seems to be in glpk itself (i think?), but it'd be nice if the bindings didn't force me to call this function that causes it to crash